### PR TITLE
Export UNSCHEDULE and ALL-SCHEDULES functions.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -5,6 +5,8 @@
   (:export
    ;; Useful macros for users
    #:schedule!
+   #:unschedule
+   #:all-schedules
    #:dry-run
    ;; Generic interface
    #:*default-next-time-limit*

--- a/src/user.lisp
+++ b/src/user.lisp
@@ -32,6 +32,9 @@ SCHEDULE-DEFINITION."
 ;; API with schedules
 ;; TODO Native inspection, pause.. etc.
 (defun all-schedules () *schedules*)
+
 (defun unschedule (schedule)
+  "Returns the same schedule object as given on input."
   (trivial-timers:unschedule-timer schedule)
-  (setf *schedules* (remove schedule *schedules*)))
+  (setf *schedules* (remove schedule *schedules*))
+  (values schedule))


### PR DESCRIPTION
Also, I've made unschedule function return the same object. This have more sense than returning all known schedules how SETF and REMOVE do.