### PR TITLE
Build fixes.

### DIFF
--- a/cl-schedule.asd
+++ b/cl-schedule.asd
@@ -18,6 +18,4 @@
                              ;; (:file "test")
                              )))
   :serial t
-  :depends-on (:bordeaux-threads :local-time))
-
-(local-time:enable-read-macros)
+  :depends-on (:bordeaux-threads :log4cl :local-time))

--- a/src/setup.lisp
+++ b/src/setup.lisp
@@ -1,6 +1,8 @@
 (in-package :cl-schedule)
 (declaim (optimize (debug 3) (safety 3)))
 
+(local-time:enable-read-macros)
+
 (defvar *schedules* nil)
 (defvar *actions* (make-hash-table))   ; an action is a time and a schedule
 (defvar *rounds* 30)              ; The scheduler schedules once every *ROUNDS* seconds.


### PR DESCRIPTION
- Depend on log4cl.
- Enable local-time read macros after it has been loaded.